### PR TITLE
WIP: Add `only` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,8 +32,9 @@ Standard library changes
 
 * The methods of `mktemp` and `mktempdir` which take a function body to pass temporary paths to no longer throw errors if the path is already deleted when the function body returns ([#33091]).
 
-#### Libdl
+* New function `only(x)` returns the one-and-only element of a collection `x`, and throws an error if `x` contains zero or multiple elements.
 
+#### Libdl
 
 #### LinearAlgebra
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -138,7 +138,7 @@ include("ntuple.jl")
 include("abstractdict.jl")
 
 include("iterators.jl")
-using .Iterators: zip, enumerate
+using .Iterators: zip, enumerate, only
 using .Iterators: Flatten, Filter, product  # for generators
 
 include("namedtuple.jl")

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -628,6 +628,7 @@ export
 
     enumerate,  # re-exported from Iterators
     zip,
+    only,
 
 # object identity and equality
     copy,

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1113,6 +1113,9 @@ Base.@propagate_inbounds function only(x)
 end
 
 # Collections of known size
+only(x::Ref) = x[]
+only(x::Number) = x
+only(x::Char) = x
 only(x::Tuple{}) = throw(ArgumentError("Tuple is empty, must contain exactly 1 element"))
 only(x::Tuple{Any}) = x[1]
 only(x::Tuple) = throw(

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -12,7 +12,7 @@ using .Base:
     @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
     tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,
     IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds, Generator, AbstractRange,
-    LinearIndices, (:), |, +, -, !==, !, <=, <, missing, map, any
+    LinearIndices, (:), |, +, -, !==, !, <=, <, missing, map, any, @boundscheck, @inbounds
 
 import .Base:
     first, last,
@@ -1100,7 +1100,7 @@ length(s::Stateful) = length(s.itr) - s.taken
 Returns the one and only element of collection `x`, and throws an `ArgumentError` if the
 collection has zero or multiple elements.
 """
-Base.@propagate_inbounds function only(x)
+@propagate_inbounds function only(x)
     i = iterate(x)
     @boundscheck if i === nothing
         throw(ArgumentError("Collection is empty, must contain exactly 1 element"))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1101,12 +1101,12 @@ Returns the one and only element of collection `x`, and throws an error if the c
 has zero or multiple elements.
 """
 Base.@propagate_inbounds function only(x)
-    i = start(x)
-    @boundscheck if done(x, i)
+    i = iterate(x)
+    @boundscheck if i === nothing
         error("Collection is empty, must contain exactly 1 element")
     end
-    (ret, i) = next(x, i)
-    @boundscheck if !done(x, i)
+    (ret, state) = i
+    @boundscheck if iterate(x, state) !== nothing
         error("Collection has multiple elements, must contain exactly 1 element")
     end
     return ret

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1097,29 +1097,31 @@ length(s::Stateful) = length(s.itr) - s.taken
 """
     only(x)
 
-Returns the one and only element of collection `x`, and throws an error if the collection
-has zero or multiple elements.
+Returns the one and only element of collection `x`, and throws an `ArgumentError` if the
+collection has zero or multiple elements.
 """
 Base.@propagate_inbounds function only(x)
     i = iterate(x)
     @boundscheck if i === nothing
-        error("Collection is empty, must contain exactly 1 element")
+        throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
     end
     (ret, state) = i
     @boundscheck if iterate(x, state) !== nothing
-        error("Collection has multiple elements, must contain exactly 1 element")
+        throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
     end
     return ret
 end
 
 # Collections of known size
-only(x::Tuple{}) = error("Tuple is empty, must contain exactly 1 element")
+only(x::Tuple{}) = throw(ArgumentError("Tuple is empty, must contain exactly 1 element"))
 only(x::Tuple{Any}) = x[1]
-only(x::Tuple) = error("Tuple contains $(length(x)) elements, must contain exactly 1 element")
-
+only(x::Tuple) = throw(
+    ArgumentError("Tuple contains $(length(x)) elements, must contain exactly 1 element")
+)
 only(a::AbstractArray{<:Any, 0}) = @inbounds return a[]
-
 only(x::NamedTuple{<:Any, <:Tuple{Any}}) = first(x)
-only(x::NamedTuple) = error("NamedTuple contains $(length(x)) elements, must contain exactly 1 element")
+only(x::NamedTuple) = throw(
+    ArgumentError("NamedTuple contains $(length(x)) elements, must contain exactly 1 element")
+)
 
 end

--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -15,4 +15,5 @@ Base.Iterators.flatten
 Base.Iterators.partition
 Base.Iterators.filter
 Base.Iterators.reverse
+Base.Iterators.only
 ```

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -183,7 +183,6 @@ end
 @test Base.IteratorEltype(repeated(0, 5)) == Base.HasEltype()
 @test Base.IteratorSize(zip(repeated(0), repeated(0))) == Base.IsInfinite()
 
-
 # product
 # -------
 
@@ -410,7 +409,6 @@ for n in [5,6]
     @test collect(partition(enumerate([1,2,3,4,5]), n))[1] ==
           [(1,1),(2,2),(3,3),(4,4),(5,5)]
 end
-
 
 @test join(map(x->string(x...), partition("Hello World!", 5)), "|") ==
       "Hello| Worl|d!"
@@ -650,22 +648,22 @@ end
 
 @testset "only" begin
     @test only([3]) === 3
-    @test_throws ErrorException only([])
-    @test_throws ErrorException only([3, 2])
+    @test_throws ArgumentError only([])
+    @test_throws ArgumentError only([3, 2])
 
     @test @inferred(only((3,))) === 3
-    @test_throws ErrorException only(())
-    @test_throws ErrorException only((3, 2))
+    @test_throws ArgumentError only(())
+    @test_throws ArgumentError only((3, 2))
 
     @test only(Dict(1=>3)) === (1=>3)
-    @test_throws ErrorException only(Dict{Int,Int}())
-    @test_throws ErrorException only(Dict(1=>3, 2=>2))
+    @test_throws ArgumentError only(Dict{Int,Int}())
+    @test_throws ArgumentError only(Dict(1=>3, 2=>2))
 
     @test only(Set([3])) === 3
-    @test_throws ErrorException only(Set(Int[]))
-    @test_throws ErrorException only(Set([3,2]))
+    @test_throws ArgumentError only(Set(Int[]))
+    @test_throws ArgumentError only(Set([3,2]))
 
     @test @inferred(only((;a=1))) === 1
-    @test_throws ErrorException only(NamedTuple())
-    @test_throws ErrorException only((a=3, b=2.0))
+    @test_throws ArgumentError only(NamedTuple())
+    @test_throws ArgumentError only((a=3, b=2.0))
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -667,6 +667,10 @@ end
     @test_throws ArgumentError only(NamedTuple())
     @test_throws ArgumentError only((a=3, b=2.0))
 
+    @test @inferred(only(1)) === 1
+    @test @inferred(only('a')) === 'a'
+    @test @inferred(only(Ref([1, 2]))) == [1, 2]
+
     @test only(1 for ii in 1:1) === 1
     @test only(1 for ii in 1:10 if ii < 2) === 1
     @test_throws ArgumentError only(1 for ii in 1:10)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -647,3 +647,25 @@ end
     @test length(collect(d)) == 2
     @test length(collect(d)) == 0
 end
+
+@testset "only" begin
+    @test only([3]) === 3
+    @test_throws ErrorException only([])
+    @test_throws ErrorException only([3, 2])
+
+    @test @inferred(only((3,))) === 3
+    @test_throws ErrorException only(())
+    @test_throws ErrorException only((3, 2))
+
+    @test only(Dict(1=>3)) === (1=>3)
+    @test_throws ErrorException only(Dict{Int,Int}())
+    @test_throws ErrorException only(Dict(1=>3, 2=>2))
+
+    @test only(Set([3])) === 3
+    @test_throws ErrorException only(Set(Int[]))
+    @test_throws ErrorException only(Set([3,2]))
+
+    @test @inferred(only((;a=1))) === 1
+    @test_throws ErrorException only(NamedTuple())
+    @test_throws ErrorException only((a=3, b=2.0))
+end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -666,4 +666,10 @@ end
     @test @inferred(only((;a=1))) === 1
     @test_throws ArgumentError only(NamedTuple())
     @test_throws ArgumentError only((a=3, b=2.0))
+
+    @test only(1 for ii in 1:1) === 1
+    @test only(1 for ii in 1:10 if ii < 2) === 1
+    @test_throws ArgumentError only(1 for ii in 1:10)
+    @test_throws ArgumentError only(1 for ii in 1:10 if ii > 2)
+    @test_throws ArgumentError only(1 for ii in 1:10 if ii > 200)
 end


### PR DESCRIPTION
The function `only(x)` returns the one-and-only element of a collection `x`, or else throws an error.