### PR TITLE
WIP: Add `dropdims(f, args..; dims, kwargs..)` for reductions to drop dims

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,8 +32,10 @@ Standard library changes
 
 * The methods of `mktemp` and `mktempdir` which take a function body to pass temporary paths to no longer throw errors if the path is already deleted when the function body returns ([#33091]).
 
-#### Libdl
+* A new `squeeze(f, A, dims)` method computes the reduction `f` over the region in
+`A` described by `dims` and then drops those dimensions from the result ([#23500]).
 
+#### Libdl
 
 #### LinearAlgebra
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -84,7 +84,15 @@ function _dropdims(A::AbstractArray, dims::Dims)
     end
     reshape(A, d::typeof(_sub(axes(A), dims)))
 end
+
 _dropdims(A::AbstractArray, dim::Integer) = _dropdims(A, (Int(dim),))
+
+"""
+    squeeze(f, A, dims)
+
+Compute reduction `f` over dimensions `dims` in array `A` and drop those dimensions from the result.
+"""
+squeeze(f, A::AbstractArray, dims::Union{Dims, Integer}) = squeeze(f(A, dims), dims)
 
 ## Unary operators ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -303,6 +303,17 @@ end
     @test_throws ArgumentError dropdims(a, dims=4)
     @test_throws ArgumentError dropdims(a, dims=6)
 
+    @test @inferred(squeeze(sum, a, 1)) == @inferred(squeeze(sum, a, (1,))) == reshape(sum(a, 1), (1, 8, 8, 1))
+    @test @inferred(squeeze(sum, a, 3)) == @inferred(squeeze(sum, a, (3,))) == reshape(sum(a, 3), (1, 1, 8, 1))
+    @test @inferred(squeeze(sum, a, 4)) == @inferred(squeeze(sum, a, (4,))) == reshape(sum(a, 4), (1, 1, 8, 1))
+    @test @inferred(squeeze(sum, a, (1, 5))) == squeeze(sum, a, (5, 1)) == reshape(sum(a, (5, 1)), (1, 8, 8))
+    @test @inferred(squeeze(sum, a, (1, 2, 5))) == squeeze(sum, a, (5, 2, 1)) == reshape(sum(a, (5, 2, 1)), (8, 8))
+    @test_throws ArgumentError squeeze(sum, a, 0)
+    @test_throws ArgumentError squeeze(sum, a, (1, 1))
+    @test_throws ArgumentError squeeze(sum, a, (1, 2, 1))
+    @test_throws ArgumentError squeeze(sum, a, (1, 1, 2))
+    @test_throws ArgumentError squeeze(sum, a, 6)
+
     sz = (5,8,7)
     A = reshape(1:prod(sz),sz...)
     @test A[2:6] == [2:6;]


### PR DESCRIPTION
- attempt to address https://github.com/JuliaLang/julia/issues/16606
- (credit Matt Bauman and Stefan Karpinski for suggesting this approach)